### PR TITLE
Fix deleting of groups

### DIFF
--- a/internal/services/sync/ldap.go
+++ b/internal/services/sync/ldap.go
@@ -102,6 +102,7 @@ func (s *ldapSyncJob) syncUser() error {
 				if err != nil {
 					return err
 				}
+				continue
 			}
 
 			if !array.ContainsEntry(ldapUser.Groups, group.Name) {


### PR DESCRIPTION
Database group deleting throws an exception if the ldap group was deleted